### PR TITLE
Update to apiVersion apps/v1

### DIFF
--- a/gke-lab-02/deploy-rolling.yaml
+++ b/gke-lab-02/deploy-rolling.yaml
@@ -1,9 +1,12 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rolling
 spec:
   replicas: 4
+  selector:
+    matchLabels:
+      app: rolling
   strategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
this solves the next error messages when trying to do `kubectl create -f deploy-rolling.yaml` from the folder `gke-lab-02`

- error: unable to recognize "deploy-rolling.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"
- error: error validating "deploy-rolling.yaml": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false